### PR TITLE
fix: readme action for push subcommand

### DIFF
--- a/src/push.sh
+++ b/src/push.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
 function push {
+  export GITHUB_ACCESS_TOKEN=$1
   cd /github/workspace/new-workflow
   git config --global --add safe.directory /github/workspace/new-workflow
   git config --global user.email "anmol+ci@clouddrove.com."
   git config --global user.name "clouddrove-ci"
-  git add . && git commit -m "update README.md"
+  git remote set-url origin https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+  git add .
+  git commit -m "update README.md" || true
   git push origin master
 }


### PR DESCRIPTION
## What

- Updated `src/push.sh` to authenticate Git before pushing README changes.

## Why

- `git push` was failing inside the Docker action container because GitHub credentials were not available there.
- The workflow was also failing when there were no README changes to commit.

## How

- Added GitHub token authentication using: `https://x-access-token:${GITHUB_ACCESS_TOKEN}@github.com/${GITHUB_REPOSITORY}.git`
- Added `|| true` to `git commit` to avoid failure when there is nothing to commit.

## Checklist

- [x] Code follows existing conventions
- [ ] Updated or added examples in `examples/`
- [x] Ran `pre-commit run -a` locally
- [ ] Updated documentation if needed
- [x] All CI checks pass

## References

<img width="1394" height="671" alt="image" src="https://github.com/user-attachments/assets/c7b889f4-7aa7-4438-b4a1-04a4c8be8d66" />

